### PR TITLE
add optional singleton style access

### DIFF
--- a/lib/ziptz.rb
+++ b/lib/ziptz.rb
@@ -4,6 +4,10 @@ require 'zlib'
 class Ziptz
   VERSION = '3.0.9'.freeze
 
+  def self.instance
+    @instance ||= new
+  end
+
   def time_zone_name(zip)
     tz_info = time_zone_info(zip)
     return unless tz_info

--- a/spec/ziptz_spec.rb
+++ b/spec/ziptz_spec.rb
@@ -106,4 +106,18 @@ RSpec.describe Ziptz do
       end
     end
   end
+
+  describe '#instance' do
+    context 'when given a 5 digit zip code' do
+      it 'matches the behavior of Ziptz.new' do
+        expect(Ziptz.instance.time_zone_name('97034')).to eq ziptz.time_zone_name('97034')
+      end
+    end
+
+    context 'when called twice' do
+      it 'returns identical instances' do
+        expect(Ziptz.instance.object_id).to eq Ziptz.instance.object_id
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds a simple instance class method so that Ziptz can be accessed from multiple locations within an app without needing to call new multiple times (therefore avoiding potentially reparseing the data file). The methods can be called by Ziptz.instance.time_zone_name

This could be modified to work as Ziptz.time_zone_name directly, though I didn't opt for that approach here.