### PR TITLE
Handle nil zip input on time_zone methods

### DIFF
--- a/lib/ziptz.rb
+++ b/lib/ziptz.rb
@@ -46,6 +46,8 @@ class Ziptz
   protected
 
   def time_zone_info(zip)
+    return unless zip
+
     db.get_first_row('select * from zip_codes where zip_code = ? limit 1', zip[0, 5])
   end
 

--- a/spec/ziptz_spec.rb
+++ b/spec/ziptz_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe Ziptz do
         expect(ziptz.time_zone_name('xyz')).to be_nil
       end
     end
+
+    context 'when nil is passed' do
+      it 'returns nil' do
+        expect(ziptz.time_zone_name(nil)).to be_nil
+      end
+    end
   end
 
   describe '#time_zone_name' do


### PR DESCRIPTION
In v4, if you pass `nil` to `time_zone_name`, it raises an `NoMethodError` exception:

```
> Ziptz.new.time_zone_name(nil)
NoMethodError: undefined method `[]' for nil:NilClass
```

However, in v3, this is gracefully handled and just returns `nil`:
```
> Ziptz.new.time_zone_name(nil)
=> nil
```

I propose that we maintain this behavior in v4 instead of raising an exception.